### PR TITLE
Improve broker header and stats layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -582,6 +582,114 @@
             gap: 15px;
             justify-content: center;
         }
+
+        /* === Broker dashboard styles === */
+        .broker-fixed-header {
+            background: linear-gradient(135deg, #4CAF50, #45a049);
+            color: white;
+            padding: 15px 30px;
+            position: sticky;
+            top: 0;
+            z-index: 999;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            gap: 20px;
+            white-space: nowrap;
+        }
+
+        .broker-fixed-header .broker-header-actions {
+            display: flex;
+            align-items: center;
+            gap: 15px;
+        }
+
+        .broker-dashboard {
+            max-width: 1100px;
+            margin: 40px auto;
+            padding: 20px;
+        }
+
+        .broker-search-bar {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 10px;
+            margin-bottom: 25px;
+        }
+
+        .broker-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 20px;
+        }
+
+        .agency-card {
+            background: white;
+            border: 2px solid #e1e5e9;
+            border-radius: 12px;
+            padding: 20px;
+            margin-bottom: 20px;
+            display: flex;
+            justify-content: space-between;
+            gap: 20px;
+            box-shadow: 0 2px 10px rgba(0,0,0,0.05);
+        }
+
+        .agency-header {
+            display: flex;
+            align-items: center;
+            gap: 10px;
+            font-weight: bold;
+            color: #4CAF50;
+            margin-bottom: 5px;
+        }
+
+        .agency-initial {
+            width: 40px;
+            height: 40px;
+            background: #4CAF50;
+            color: white;
+            border-radius: 50%;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            font-size: 18px;
+            font-weight: bold;
+        }
+
+        .agency-meta {
+            color: #555;
+            font-size: 14px;
+            margin-bottom: 8px;
+        }
+
+        .agency-status {
+            font-size: 13px;
+            color: #777;
+        }
+
+        .policy-count {
+            font-size: 28px;
+            color: #4CAF50;
+            font-weight: bold;
+            display: flex;
+            gap: 6px;
+            align-items: baseline;
+            justify-content: flex-end;
+        }
+        .policy-count .policy-label {
+            font-size: 14px;
+            color: #555;
+            font-weight: normal;
+        }
+
+        .agency-actions {
+            margin-top: 10px;
+            display: flex;
+            gap: 10px;
+            justify-content: flex-end;
+        }
     </style>
 </head>
 <body>
@@ -654,34 +762,24 @@
 
         <!-- Broker / Master-Admin Screen -->
     <div id="brokerScreen" class="screen">
-      <div class="login-form">
-        <h2 style="text-align: center; margin-bottom: 30px; color: #4CAF50;">
-          Вход Брокер / Админ
-        </h2>
-        <div>
-          <h4 style="margin-bottom: 20px;">Управление на агенции</h4>
-          <ul id="agenciesList" style="list-style: none; padding: 0; margin-bottom: 20px;">
-            <!-- JS will inject each agency here -->
-          </ul>
-          <div style="display: flex; gap: 10px; margin-bottom: 30px;">
-            <input
-              type="text"
-              id="newAgencyName"
-              class="form-control"
-              placeholder="Име на нова агенция"
-              style="flex:1;"
-            >
-            <button class="btn" onclick="addAgency()">Добави</button>
-          </div>
-          <button
-            type="button"
-            class="btn"
-            style="width: 100%; margin-bottom: 15px;"
-            onclick="showScreen('loginScreen')"
-          >
-            Изход
-          </button>
+        <div class="broker-fixed-header">
+          <span class="broker-info">🔒 LetMeIns - Брокерски портал • LetMeIns Bulgaria Брокер</span>
+          <span class="broker-header-actions">
+            <span>Управление на агенции</span>
+            <button class="btn btn-secondary" onclick="showScreen('loginScreen')">Изход</button>
+          </span>
         </div>
+      <div class="broker-dashboard">
+        <div class="broker-search-bar">
+          <input type="text" id="searchAgency" class="form-control" placeholder="Търси по име на агенция, град или статус" style="flex:1;">
+          <button class="btn btn-secondary" onclick="clearAgencySearch()">Изчисти търсенето</button>
+          <button class="btn" onclick="addAgency()">+ Добави агенция</button>
+        </div>
+        <div class="broker-header">
+          <h2>Партньорски туристически агенции</h2>
+          <span>Общо агенции: <span id="agencyCount">0</span></span>
+        </div>
+        <div id="agencyCards"></div>
       </div>
     </div>
 
@@ -1621,15 +1719,17 @@
         }
 
         function createOfferWithCompany(companyName, price) {
-            var newOfferNumber = 'OF-2025-' + String(offers.length + 1).padStart(3, '0');
-            var newOffer = {
-                id: newOfferNumber,
-                client: 'Нов клиент',
-                destination: currentOfferData.destination,
-                dates: currentOfferData.departureDate + ' - ' + currentOfferData.returnDate,
-                premium: price + ' лв.',
-                company: companyName,
-                travelersCount: currentOfferData.travelersCount,
+           var newOfferNumber = 'OF-2025-' + String(offers.length + 1).padStart(3, '0');
+           var client = prompt('Име на клиента:');
+           if (!client) return;
+           var newOffer = {
+               id: newOfferNumber,
+               client: client,
+               destination: currentOfferData.destination,
+               dates: currentOfferData.departureDate + ' - ' + currentOfferData.returnDate,
+               premium: price + ' лв.',
+               company: companyName,
+               travelersCount: currentOfferData.travelersCount,
                 status: 'offer'
             };
 
@@ -2252,7 +2352,11 @@ var masterUser = { email: 'master@travelxyz.com', password: 'YOUR_MASTER_PASSWOR
 
 // 2) In-memory list of agencies (initialize from your real data if you have it)
 var agencies = [
-  { name: 'Туристическа агенция XYZ', email:'xyz@travelxyz.com', password:'xyzpass' }
+  { name: 'Travel Pro Sofia', city: 'София', email: 'contact@travelpro.bg', phone: '+359 2 123 4567', status: 'active', since: 'март 2023', last: 'днес', policies: 234 },
+  { name: 'Bulgaria Tours', city: 'Варна', email: 'info@bulgariatours.com', phone: '+359 52 123 456', status: 'active', since: 'януари 2023', last: 'вчера', policies: 156 },
+  { name: 'Sunny Travel', city: 'Пловдив', email: 'office@sunnytravel.bg', phone: '+359 32 987 654', status: 'active', since: 'май 2023', last: 'днес', policies: 89 },
+  { name: 'Mountain Tours', city: 'Банско', email: 'info@mountaintours.bg', phone: '+359 749 123 789', status: 'active', since: 'юни 2023', last: 'преди 2 дни', policies: 67 },
+  { name: 'Coast Travel', city: 'Бургас', email: 'sales@coasttravel.bg', phone: '+359 56 456 123', status: 'inactive', since: '', last: 'преди 1 седмица', policies: 0 }
 ];
 
 // 3) Entry point for broker login
@@ -2269,25 +2373,50 @@ function showBrokerScreen() {
   renderAgencies();
 }
 
-// 5) Populate the UL with agencies
+// 5) Render broker agency cards
 function renderAgencies() {
-  var ul = document.getElementById('agenciesList');
-  ul.innerHTML = '';
+  var container = document.getElementById('agencyCards');
+  var countEl = document.getElementById('agencyCount');
+  container.innerHTML = '';
+  if (countEl) countEl.textContent = agencies.length;
   agencies.forEach((a,i) => {
-    var li = document.createElement('li');
-    li.innerHTML = `
-      ${a.name}
-      <button class="btn btn-primary" onclick="loginAgency(${i})">Login</button>
-      <button class="btn btn-danger" onclick="removeAgency(${i})">Remove</button>
+    var card = document.createElement('div');
+    card.className = 'agency-card';
+    var initials = a.name.split(' ').map(w => w[0]).join('').substring(0,2).toUpperCase();
+    var statusText = a.status === 'active'
+      ? `✅ Активна от ${a.since} • Последна активност: ${a.last}`
+      : `⏸️ Неактивна • Последна активност: ${a.last}`;
+    card.innerHTML = `
+      <div class="info">
+        <div class="agency-header">
+          <div class="agency-initial">${initials}</div>
+          <span>${a.name}</span>
+        </div>
+        <div class="agency-meta">📍 ${a.city} • 📧 ${a.email} • 📞 ${a.phone}</div>
+        <div class="agency-status">${statusText}</div>
+      </div>
+      <div class="stats">
+        <div class="policy-count">${a.policies} <span class="policy-label">полици този месец</span></div>
+        <div class="agency-actions">
+          <button class="btn btn-secondary">📊 Експорт полици</button>
+          <button class="btn" onclick="loginAgency(${i})">вход</button>
+          <button class="btn btn-danger" onclick="removeAgency(${i})">✖</button>
+        </div>
+      </div>
     `;
-    ul.appendChild(li);
+    container.appendChild(card);
   });
+}
+
+function clearAgencySearch() {
+  var input = document.getElementById('searchAgency');
+  if (input) input.value = '';
 }
 
 // 6) Add / remove agencies
 function addAgency() {
-  var name = document.getElementById('newAgencyName').value.trim();
-  if (!name) return showAlert('Грешка','Въведете име!');
+  var name = prompt('Име на новата агенция:');
+  if (!name) return;
   var email = prompt('Email for this agency:');
   var pass = prompt('Password for this agency:');
   agencies.push({ name, email, password: pass });

--- a/index.html
+++ b/index.html
@@ -682,6 +682,7 @@
             font-size: 14px;
             color: #555;
             font-weight: normal;
+
         }
 
         .agency-actions {
@@ -775,6 +776,7 @@
           <button class="btn btn-secondary" onclick="clearAgencySearch()">Изчисти търсенето</button>
           <button class="btn" onclick="addAgency()">+ Добави агенция</button>
         </div>
+
         <div class="broker-header">
           <h2>Партньорски туристически агенции</h2>
           <span>Общо агенции: <span id="agencyCount">0</span></span>


### PR DESCRIPTION
## Summary
- refine broker portal sticky header into a single line
- display policy-month text beside the policy count
- adjust CSS for header and policy count
- prompt for client name when creating offer

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_685d0c2632b483288662910489fad8d8